### PR TITLE
python-pytest: update dependency

### DIFF
--- a/lang/python/python-pytest/Makefile
+++ b/lang/python/python-pytest/Makefile
@@ -34,7 +34,7 @@ define Package/python3-pytest
 	+python3 \
 	+python3-pluggy \
 	+python3-packaging \
-	+python3-tomli \
+	+python3-toml \
 	+python3-exceptiongroup \
 	+python3-iniconfig
 endef


### PR DESCRIPTION
fix mistyping form "python3-tomli" to "python3-toml"

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
